### PR TITLE
[FIX] tag push 실패 문제 해결

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,24 +128,29 @@ jobs:
           chmod +x tools/alertSuccess.sh
           tools/alertSuccess.sh "$SLACK_WEBHOOK_URL" ${GITHUB_REPO_URL} "${{ steps.pr_info.outputs.pull_request_title }}"
   
-  ## below code is from .github/releaseAction.yml
+  ## below code is from .github/releaseAction.yml and modified
   ## name: Release Tag
   ## only runs when alert_deploy_success job is done
   build:
     runs-on: ubuntu-latest
+    permissions: write-all
     needs: alert_deploy_success
     if: ${{ success() }}
     steps:
-    - uses: actions/checkout@v2
-    - name: 버전 정보 추출
-      run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
-      id: extract_version_name   
-          
-    - name: Release 생성 
-      uses: actions/create-release@v1
-      env: 
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with: 
-        tag_name: ${{ steps.extract_version_name.outputs.version }} 
-        release_name: ${{ steps.extract_version_name.outputs.version }} 
-      
+      - uses: actions/checkout@v2
+      - name: 버전 정보 추출
+        id: extract_version_name 
+        shell: bash  
+        run: |
+          VAR=$(echo '${{ github.event.pull_request.title }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+
+          echo $VAR
+          echo "version=${VAR}" >> $GITHUB_OUTPUT
+
+      - name: Release 생성 
+        uses: actions/create-release@v1
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with: 
+          tag_name: "v${{ steps.extract_version_name.outputs.version }}" 
+          release_name: "${{ steps.extract_version_name.outputs.version }}" 


### PR DESCRIPTION
#### 두가지 문제가 있었습니다.
1. commit 메세지를 읽지만 head commit이 merge이므로 버전 정보 없음
- 원인: branch이름을 v1.0.0 과 같은 형식으로 적는다면 잘 실행되겠으나, 저희는 해당되지 않아 문제가 발생했습니다.
- 해결: commit메세지 대신 PR title에서 버전 정보를 읽어오도록 했습니다.
2. permission없음
- 해결: write 권한을 추가했습니다.